### PR TITLE
feat: Rename logic is contained in sperate react component.

### DIFF
--- a/src/components/visualEditor/nodeInfoForm.tsx
+++ b/src/components/visualEditor/nodeInfoForm.tsx
@@ -3,7 +3,7 @@ import { CsmNodeProps, isState, isStateMachine, ReactFlowContextProps} from "../
 import {ActionCategory, ActionType, MemoryUnit, ServiceLevel, ServiceType, TimeUnit} from "../../enums.ts";
 import Action from "../../classes/action.ts";
 import {ReactFlowContext} from "../../utils.ts";
-
+import RenameNodeComponent from "./renameNodeComponent.tsx";
 
 /**
  * NodeInfoForm Component
@@ -746,6 +746,7 @@ export default function NodeInfoForm() {
     return (
         showSidebar && selectedNode && (
             <div className="node-form">
+                <RenameNodeComponent></RenameNodeComponent>
                 <form onSubmit={onFormSubmit}>
                     <h3>Hi mom! It's me {stateOrStateMachineService.getName(selectedNode.data)}!</h3>
                     <label htmlFor="name">Name: </label>

--- a/src/components/visualEditor/nodeInfoForm.tsx
+++ b/src/components/visualEditor/nodeInfoForm.tsx
@@ -28,7 +28,6 @@ export default function NodeInfoForm() {
         selectedNode,
         stateOrStateMachineService,
         showSidebar,
-        nameInput,
         setNameInput,
         setEdges,
         actionService,
@@ -163,8 +162,6 @@ export default function NodeInfoForm() {
         if (!selectedNode) return;
 
         const formElements = event.currentTarget.elements as typeof event.currentTarget.elements & {
-            // GENERIC
-            name: HTMLInputElement,
             "delay-input-value": HTMLInputElement,
             "save-as-named-action-checkbox": HTMLInputElement,
 
@@ -247,33 +244,12 @@ export default function NodeInfoForm() {
 
 
 
-        const newName = formElements.name.value;
+
         const delay = formElements["delay-input-value"]?.value
         const saveAsNamedAction = formElements["save-as-named-action-checkbox"]?.checked;
 
         console.log("EXISTING ACTION ",existingActionName)
 
-        const oldName = stateOrStateMachineService.getName(selectedNode.data);
-
-        if (!stateOrStateMachineService.isNameUnique(newName) && newName !== oldName) {
-            console.error(`StateOrStateMachine name ${newName} already exists!`);
-            return;
-        }
-
-        if (newName && newName !== oldName) {
-            const newNodes = nodes.map(node => {
-                if (node.id === selectedNode.id) {
-                    const newData = stateOrStateMachineService.setName(newName, node.data);
-                    return { ...node, data: newData };
-                }
-                return node;
-            });
-
-            stateOrStateMachineService.unregisterName(oldName);
-            stateOrStateMachineService.registerName(newName);
-            setNodes(newNodes);
-            updateTransitionsOnRename(oldName, newName);
-        }
 
         let newAction = undefined;
 
@@ -417,11 +393,8 @@ export default function NodeInfoForm() {
         setNewActionName("")
 
 
-    }, [nodes, setNodes, selectedNode, stateOrStateMachineService, updateTransitionsOnRename]);
-
-    const onNameInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setNameInput(event.target.value);
-    };
+    }, [selectedNode, stateOrStateMachineService, nodes, setNodes, updateTransitionsOnRename, actionService, newEventName, eventService, contextService, selectedActionType]);
+    
 
     // TODO: Style to make it more readable
     // Show Category etc.
@@ -749,9 +722,6 @@ export default function NodeInfoForm() {
                 <RenameNodeComponent></RenameNodeComponent>
                 <form onSubmit={onFormSubmit}>
                     <h3>Hi mom! It's me {stateOrStateMachineService.getName(selectedNode.data)}!</h3>
-                    <label htmlFor="name">Name: </label>
-                    <input type="text" id="name" name="name" value={nameInput} onChange={onNameInputChange} />
-
                     <div className="from-action-section">
                         <label htmlFor="select-action-type">Add action: </label>
                         <select id="select-action-type" name="select-action-type" onChange={onActionTypeSelect}

--- a/src/components/visualEditor/renameNodeComponent.tsx
+++ b/src/components/visualEditor/renameNodeComponent.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from "react";
+import React, {useCallback, useContext, useEffect, useState} from "react";
 import {ReactFlowContext} from "../../utils.ts";
 import {ReactFlowContextProps} from "../../types.ts";
 
@@ -8,6 +8,7 @@ export default function RenameNodeComponent() {
     const [nodeNameInput, setNodeNameInput] = useState<string>("");
     const {
         selectedNode,
+        setEdges,
         stateOrStateMachineService
     } = context;
 
@@ -18,10 +19,58 @@ export default function RenameNodeComponent() {
         }
     }, [selectedNode, stateOrStateMachineService]);
 
+    /**
+     * Updates the transitions when a node is renamed.
+     *
+     * This function updates the source and target names of transitions in the edges
+     * whenever a node is renamed. It ensures that any transition involving the renamed
+     * node reflects the new name.
+     *
+     * @param {string} oldName - The old name of the node before renaming.
+     * @param {string} newName - The new name of the node after renaming.
+     */
+    const updateTransitionsOnRename = useCallback((oldName: string, newName: string) => {
+        setEdges(edges => edges.map(edge => {
+            if (edge.data?.transition) {
+                const transition = edge.data.transition;
+                let updated = false;
+                if (transition.getSource() === oldName) {
+                    transition.setSource(newName);
+                    updated = true;
+                }
+                if (transition.getTarget() === oldName) {
+                    transition.setTarget(newName);
+                    updated = true;
+                }
+                if (updated) {
+                    return { ...edge, data: { ...edge.data, transition } };
+                }
+            }
+            return edge;
+        }));
+    }, [setEdges]);
+
+    const onNodeNameInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+        setNodeNameInput(event.target.value);
+    },[setNodeNameInput]);
+
+    const onFormSubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const formElements = event.currentTarget.elements as typeof event.currentTarget.elements & {
+            [INPUT_FIELD_NAME]: HTMLInputElement
+        };
+        const newName = formElements[INPUT_FIELD_NAME]?.value;
+        console.log(`Logging NEW NAME FROM COMPONENT ${newName}`);
+
+    },[])
+
+
+
     return (
         <div className={"rename-node-form-container"}>
-            <form>
-                <input type={"text"} name={INPUT_FIELD_NAME} value={nodeNameInput}/>
+            <form onSubmit={onFormSubmit}>
+                <input type={"text"} name={INPUT_FIELD_NAME} value={nodeNameInput} onChange={onNodeNameInputChange}/>
+                <button type={"submit"}>Save</button>
             </form>
         </div>
     )

--- a/src/components/visualEditor/renameNodeComponent.tsx
+++ b/src/components/visualEditor/renameNodeComponent.tsx
@@ -1,0 +1,28 @@
+import {useContext, useEffect, useState} from "react";
+import {ReactFlowContext} from "../../utils.ts";
+import {ReactFlowContextProps} from "../../types.ts";
+
+export default function RenameNodeComponent() {
+    const INPUT_FIELD_NAME = "placeholder"
+    const context = useContext(ReactFlowContext) as ReactFlowContextProps;
+    const [nodeNameInput, setNodeNameInput] = useState<string>("");
+    const {
+        selectedNode,
+        stateOrStateMachineService
+    } = context;
+
+
+    useEffect(() => {
+        if (selectedNode) {
+            setNodeNameInput(stateOrStateMachineService.getName(selectedNode.data));
+        }
+    }, [selectedNode, stateOrStateMachineService]);
+
+    return (
+        <div className={"rename-node-form-container"}>
+            <form>
+                <input type={"text"} name={INPUT_FIELD_NAME} value={nodeNameInput}/>
+            </form>
+        </div>
+    )
+}


### PR DESCRIPTION
All logic related to the renaiming of nodes is now in a seperate component. Removed the fucntionality from nodeInfoForm.